### PR TITLE
Support min pool size of 0 in constructor

### DIFF
--- a/lib/advanced-pool.js
+++ b/lib/advanced-pool.js
@@ -114,7 +114,7 @@ Pool = function (options) {
 		// pool name
 		name: options.name || 'pool',
 		// minimum number of objects in the pool
-		min: options.min || 2,
+		min: options.min === 0 ? 0 : (options.min || 2),
 		// maximum number of objects in the pool
 		max: options.max || 4,
 		// how many objects are in the process of being created right now


### PR DESCRIPTION
There is a slight bug in the constructor which actually does not allow to create a pool with the minimal size of 0.

(Workaround is to call `adjustLimits` after creating the pool + wait for the timeout to destroy the objects.)